### PR TITLE
Avoid bind errors

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -254,9 +254,8 @@ def start_grpc_client(load_stubs, spawn_process, spec_dir, grpc_port):
         stubs = load_stubs(proto_name)
         stub_cls = getattr(stubs, "{}Stub".format(service_name))
 
-        zmq_port = find_free_port()
-        transport = RemoteClientTransport.bind(
-            context, zmq.REQ, "tcp://127.0.0.1:{}".format(zmq_port)
+        transport, zmq_port = RemoteClientTransport.bind_to_free_port(
+            context, zmq.REQ, "tcp://127.0.0.1"
         )
 
         spawn_process(

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -44,7 +44,8 @@ class TestConcurrency:
 
         for index, future in enumerate(futures):
             result = future.result()
-            assert [(response.message, response.seqno) for response in result] == [
+            responses = [(response.message, response.seqno) for response in result]
+            assert responses == [
                 (string.ascii_uppercase[index], 1),
                 (string.ascii_uppercase[index], 2),
             ]
@@ -114,14 +115,12 @@ class TestConcurrency:
 
         for index, future in enumerate(futures):
             result = future.result()
+            responses = [(response.seqno, response.message) for response in result]
             if index % 2 == 0:
-                assert [
-                    (response.seqno, response.message) for response in result
-                ] == list(enumerate(string.ascii_uppercase, 1))
+                expected = list(enumerate(string.ascii_uppercase, 1))
             else:
-                assert [
-                    (response.seqno, response.message) for response in result
-                ] == list(enumerate(string.ascii_lowercase, 1))
+                expected = list(enumerate(string.ascii_lowercase, 1))
+            assert responses == expected
 
         # verify messages from concurrent requests are interleaved
         # there is a 1/626! chance of concurrent requests being handled in order,

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -43,7 +43,7 @@ class TestConcurrency:
             )
 
         for index, future in enumerate(futures):
-            result = future.result()
+            result = list(future.result())
             responses = [(response.message, response.seqno) for response in result]
             assert responses == [
                 (string.ascii_uppercase[index], 1),
@@ -114,7 +114,7 @@ class TestConcurrency:
             )
 
         for index, future in enumerate(futures):
-            result = future.result()
+            result = list(future.result())
             responses = [(response.seqno, response.message) for response in result]
             if index % 2 == 0:
                 expected = list(enumerate(string.ascii_uppercase, 1))


### PR DESCRIPTION
Avoid inherent race condition in `find_free_port` by getting ZeroMQ to bind to a random port. Fixes various flakiness.