### PR TITLE
Context data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,9 @@ sudo: false
 language: python
 services:
   - docker
-  - rabbitmq
+
+before_install:
+  - docker run -d --hostname rabbitmq --name rabbitmq -p 15672:15672 -p 5672:5672 -e RABBITMQ_DEFAULT_USER=guest -e RABBITMQ_DEFAULT_PASS=guest rabbitmq:3-management
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 services:
   - docker
+  - rabbitmq
 
 install:
   - pip install tox

--- a/nameko_grpc/context.py
+++ b/nameko_grpc/context.py
@@ -1,7 +1,63 @@
 # -*- coding: utf-8 -*-
+import json
+
+
+METADATA_PREFIX = "x-nameko-"
+
+
+def encode_value(value):
+    # TODO use nameko.serialization
+    return json.dumps(value)
+
+
+def decode_value(value):
+    # TODO use nameko.serialization
+    return json.loads(value)
+
+
+def metadata_from_context_data(data):
+    """ Utility function transforming a `data` dictionary into metadata suitable
+    for a GRPC stream.
+    """
+    metadata = []
+    for key, value in data.items():
+        name = "{}{}".format(METADATA_PREFIX, key)
+        value = encode_value(value)
+        metadata.append((name, value))
+    return metadata
+
+
+def context_data_from_metadata(metadata):
+    """ Utility function transforming `metadata` into a context data dictionary.
+`
+    Metadata may have been encoded at the client by `metadata_from_context_data`, or
+    it may be "normal" GRPC metadata. In this case, duplicate values are allowed;
+    they become a list in the context data.
+    """
+    data = {}
+
+    for name, value in metadata:
+        if name.startswith(METADATA_PREFIX):
+            _, key = name.split(METADATA_PREFIX, 1)
+            data[key] = decode_value(value)
+        else:
+            if name in data:
+                try:
+                    data[name].append(value)
+                except AttributeError:
+                    data[name] = [data[name], value]
+            else:
+                data[name] = value
+
+    return data
 
 
 class GrpcContext:
+    """ Context object passed to GRPC methods.
+
+    Gives access to request metadata and allows response metadata to be set.
+    """
+
     def __init__(self, request_stream, response_stream):
         self.request_stream = request_stream
         self.response_stream = response_stream

--- a/nameko_grpc/dependency_provider.py
+++ b/nameko_grpc/dependency_provider.py
@@ -7,11 +7,20 @@ from urllib.parse import urlparse
 from grpc import StatusCode
 from nameko.extensions import DependencyProvider
 
-from nameko_grpc.client import ClientConnectionManager, Proxy
+from nameko_grpc.client import ClientConnectionManager, Method
 from nameko_grpc.exceptions import GrpcError
 
 
 log = getLogger(__name__)
+
+
+class Proxy:
+    def __init__(self, client, context_data):
+        self.client = client
+        self.context_data = context_data
+
+    def __getattr__(self, name):
+        return Method(self.client, name, context_data=self.context_data)
 
 
 class GrpcProxy(DependencyProvider):
@@ -82,4 +91,4 @@ class GrpcProxy(DependencyProvider):
         return response_stream
 
     def get_dependency(self, worker_ctx):
-        return Proxy(self)
+        return Proxy(self, worker_ctx.context_data)

--- a/nameko_grpc/entrypoint.py
+++ b/nameko_grpc/entrypoint.py
@@ -12,7 +12,7 @@ from nameko.extensions import Entrypoint, SharedExtension, register_entrypoint
 from nameko_grpc.compression import SUPPORTED_ENCODINGS, select_algorithm
 from nameko_grpc.connection import ConnectionManager
 from nameko_grpc.constants import Cardinality
-from nameko_grpc.context import GrpcContext
+from nameko_grpc.context import GrpcContext, context_data_from_metadata
 from nameko_grpc.exceptions import GrpcError
 from nameko_grpc.inspection import Inspector
 from nameko_grpc.streams import ReceiveStream, SendStream
@@ -240,8 +240,7 @@ class Grpc(Entrypoint):
         args = (request, context)
         kwargs = {}
 
-        # context_data = self.unpack_message_headers(message)
-        context_data = {}
+        context_data = context_data_from_metadata(context.invocation_metadata())
 
         handle_result = partial(self.handle_result, response_stream)
         try:

--- a/nameko_grpc/headers.py
+++ b/nameko_grpc/headers.py
@@ -74,6 +74,14 @@ def encode_header(header):
     return name, value
 
 
+def comma_join(values):
+    if all(map(lambda item: isinstance(item, bytes), values)):
+        separator = b","
+    else:
+        separator = ","
+    return separator.join(values)
+
+
 class HeaderManager:
     def __init__(self):
         """
@@ -101,7 +109,7 @@ class HeaderManager:
                 matches.append(value)
         if not matches:
             return default
-        return ",".join(matches)
+        return comma_join(matches)
 
     def set(self, *headers, from_wire=False):
         """ Set headers.

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,6 @@ forced_separate=
 default_section=THIRDPARTY
 lines_after_imports=2
 skip=.tox,.git
+[tool:pytest]
+markers =
+    equivalence: mark a test as an equivalence test.

--- a/test/spec/advanced.proto
+++ b/test/spec/advanced.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package nameko;
+
+service advanced {
+  rpc unary_unary (SimpleRequest) returns (SimpleReply) {}
+  rpc unary_stream (SimpleRequest) returns (stream SimpleReply) {}
+  rpc stream_unary (stream SimpleRequest) returns (SimpleReply) {}
+  rpc stream_stream (stream SimpleRequest) returns (stream SimpleReply) {}
+}
+
+
+message SimpleRequest {
+  string value = 1;
+}
+
+
+
+message SimpleReply {
+  string message = 1;
+}
+

--- a/test/spec/advanced_nameko.py
+++ b/test/spec/advanced_nameko.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import base64
+import json
+
+from nameko.extensions import DependencyProvider
+
+from nameko_grpc.entrypoint import Grpc
+
+import advanced_pb2_grpc
+from advanced_pb2 import SimpleReply
+
+
+grpc = Grpc.implementing(advanced_pb2_grpc.advancedStub)
+
+
+class BytesEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode("utf-8")
+        return json.JSONEncoder.default(self, obj)
+
+
+class ContextData(DependencyProvider):
+    def get_dependency(self, worker_ctx):
+        return worker_ctx.context_data
+
+
+class advanced:
+    name = "advanced"
+
+    context_data = ContextData()
+
+    @grpc
+    def unary_unary(self, request, context):
+        message = json.dumps(self.context_data, cls=BytesEncoder)
+        return SimpleReply(message=message)

--- a/test/test_basic.py
+++ b/test/test_basic.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+import pytest
 
 
+@pytest.mark.equivalence
 class TestStandard:
     def test_unary_unary(self, client, protobufs):
         response = client.unary_unary(protobufs.ExampleRequest(value="A"))
@@ -35,6 +37,7 @@ class TestStandard:
         ]
 
 
+@pytest.mark.equivalence
 class TestLarge:
     def test_large_unary_request(self, client, protobufs):
         response = client.unary_unary(
@@ -69,6 +72,7 @@ class TestLarge:
         ]
 
 
+@pytest.mark.equivalence
 class TestFuture:
     def test_unary_unary(self, client, protobufs):
         response_future = client.unary_unary.future(protobufs.ExampleRequest(value="A"))

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -6,6 +6,7 @@ from mock import patch
 from nameko_grpc.exceptions import GrpcError
 
 
+@pytest.mark.equivalence
 class TestCompression:
     """ Some of these tests are incomplete because the standard Python GRPC client
     and/or server don't conform to the spec.

--- a/test/test_concurrency.py
+++ b/test/test_concurrency.py
@@ -3,9 +3,12 @@ import json
 import random
 import string
 
+import pytest
+
 from nameko_grpc.constants import Cardinality
 
 
+@pytest.mark.equivalence
 class TestConcurrency:
     def test_unary_unary(self, client, protobufs, instrumented, client_type):
 
@@ -130,6 +133,7 @@ class TestConcurrency:
         assert [req.value for req in captured_requests[:26]] != string.ascii_uppercase
 
 
+@pytest.mark.equivalence
 class TestMultipleClients:
     def test_unary_unary(self, start_client, server, protobufs):
 

--- a/test/test_context_data.py
+++ b/test/test_context_data.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+import json
+
+import pytest
+from nameko.rpc import rpc
+from nameko.standalone.rpc import ServiceRpcProxy
+
+from nameko_grpc.dependency_provider import GrpcProxy
+
+
+@pytest.fixture(autouse=True)
+def stubs(load_stubs):
+    return load_stubs("advanced")
+
+
+@pytest.fixture(autouse=True)
+def protobufs(load_protobufs):
+    return load_protobufs("advanced")
+
+
+class TestContextData:
+    @pytest.fixture
+    def grpc_server(self, start_nameko_server):
+        start_nameko_server("advanced")
+
+    @pytest.fixture
+    def grpc_client(self, start_client, grpc_server):
+        return start_client("advanced")
+
+    @pytest.fixture
+    def amqprpc_service(
+        self, container_factory, rabbit_config, grpc_server, protobufs, stubs, grpc_port
+    ):
+        class AmqpRpcService:
+            name = "amqp"
+
+            advanced_grpc = GrpcProxy(
+                "//127.0.0.1:{}".format(grpc_port), stubs.advancedStub
+            )
+
+            @rpc
+            def proxy(self):
+                response = self.advanced_grpc.unary_unary(
+                    protobufs.SimpleRequest(value="A"),
+                    metadata=[("x", "X"), ("x-bin", b"\x0a\x0b\x0a\x0b\x0a\x0b")],
+                )
+                return response.message
+
+        container = container_factory(AmqpRpcService, rabbit_config)
+        container.start()
+
+    @pytest.mark.parametrize(
+        "metadata,expected_key,expected_value",
+        [
+            # simple
+            ([("a", "A")], "a", "A"),
+            # duplicate names
+            ([("a", "A1"), ("a", "A2")], "a", ["A1", "A2"]),
+            # # binary
+            ([("a-bin", b"\x0a\x0b\x0a\x0b\x0a\x0b")], "a-bin", "CgsKCwoL"),
+            # # duplicate binary
+            (
+                [
+                    ("a-bin", b"\x01\x01\x01\x01\x01\x01"),
+                    ("a-bin", b"\x02\x02\x02\x02\x02\x02"),
+                ],
+                "a-bin",
+                ["AQEBAQEB", "AgICAgIC"],
+            ),
+        ],
+    )
+    def test_request_metadata_available_as_context_data(
+        self, grpc_client, protobufs, metadata, expected_key, expected_value
+    ):
+        response = grpc_client.unary_unary(
+            protobufs.SimpleRequest(value="A"), metadata=metadata
+        )
+        assert json.loads(response.message)[expected_key] == expected_value
+
+    @pytest.mark.usefixtures("predictable_call_ids")
+    def test_dependency_provider_includes_context_data_in_grpc_request_metadata(
+        self, amqprpc_service, rabbit_config
+    ):
+        with ServiceRpcProxy(
+            "amqp", rabbit_config, context_data={"a": "A"}
+        ) as proxy_rpc:
+
+            context_data = json.loads(proxy_rpc.proxy())
+
+            # added by RPC client, propagated by GRPC
+            assert context_data["a"] == "A"
+
+            # added by GRPC client as metadata
+            assert context_data["x"] == "X"
+            assert context_data["x-bin"] == "CgsKCwoL"  # base64-encoded for response
+
+            # NOTE adding binary objects to context_data will cause problems for
+            # extensions that can't serialize them (e.g. AMQP entrypoints in their
+            # default configuration); this is a general problem when mixing extensions.
+            # opportunity to improve this when nameko grows its own serialization layer
+
+            # call id stack is propagated
+            assert context_data["call_id_stack"] == [
+                "standalone_rpc_proxy.call.0",
+                "amqp.proxy.1",
+                "advanced.unary_unary.2",
+            ]

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -11,6 +11,7 @@ from nameko_grpc.constants import Cardinality
 from nameko_grpc.exceptions import GrpcError
 
 
+@pytest.mark.equivalence
 class TestMethodNotFound:
     @pytest.fixture(autouse=True)
     def unregister_grpc_method(self, stubs):
@@ -35,6 +36,7 @@ class TestMethodNotFound:
         assert error.value.details == "Method not found!"
 
 
+@pytest.mark.equivalence
 class TestDeadlineExceededAtClient:
     @pytest.fixture
     def protobufs(self, compile_proto, spec_dir):
@@ -74,6 +76,7 @@ class TestDeadlineExceededAtClient:
         assert error.value.details == "Deadline Exceeded"
 
 
+@pytest.mark.equivalence
 class TestDeadlineExceededAtServer:
     @pytest.fixture
     def protobufs(self, compile_proto, spec_dir):
@@ -130,6 +133,7 @@ class TestDeadlineExceededAtServer:
     # correctly (over and above these equivalence tests)
 
 
+@pytest.mark.equivalence
 class TestMethodException:
     def test_error_before_response(self, client, protobufs):
         with pytest.raises(GrpcError) as error:


### PR DESCRIPTION
Adds support for populating Nameko worker context data with metadata, and propagating context data over GRPC calls as metadata.